### PR TITLE
Add JPA entities for OdontoVision domain

### DIFF
--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Auditoria.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Auditoria.java
@@ -1,0 +1,114 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "auditoria")
+public class Auditoria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tabela_afetada", nullable = false, length = 50)
+    private String tabelaAfetada;
+
+    @Column(name = "tipo_operacao", nullable = false, length = 10)
+    private String tipoOperacao;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id")
+    private Usuario usuario;
+
+    @Column(name = "data_operacao")
+    private LocalDateTime dataOperacao;
+
+    @Column(name = "valores_antigos", columnDefinition = "TEXT")
+    private String valoresAntigos;
+
+    @Column(name = "valores_novos", columnDefinition = "TEXT")
+    private String valoresNovos;
+
+    public Auditoria() {
+    }
+
+    public Auditoria(String tabelaAfetada, String tipoOperacao, LocalDateTime dataOperacao) {
+        this.tabelaAfetada = tabelaAfetada;
+        this.tipoOperacao = tipoOperacao;
+        this.dataOperacao = dataOperacao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTabelaAfetada() {
+        return tabelaAfetada;
+    }
+
+    public void setTabelaAfetada(String tabelaAfetada) {
+        this.tabelaAfetada = tabelaAfetada;
+    }
+
+    public String getTipoOperacao() {
+        return tipoOperacao;
+    }
+
+    public void setTipoOperacao(String tipoOperacao) {
+        this.tipoOperacao = tipoOperacao;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public LocalDateTime getDataOperacao() {
+        return dataOperacao;
+    }
+
+    public void setDataOperacao(LocalDateTime dataOperacao) {
+        this.dataOperacao = dataOperacao;
+    }
+
+    public String getValoresAntigos() {
+        return valoresAntigos;
+    }
+
+    public void setValoresAntigos(String valoresAntigos) {
+        this.valoresAntigos = valoresAntigos;
+    }
+
+    public String getValoresNovos() {
+        return valoresNovos;
+    }
+
+    public void setValoresNovos(String valoresNovos) {
+        this.valoresNovos = valoresNovos;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Auditoria auditoria)) return false;
+        return Objects.equals(id, auditoria.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/ChecklistDiario.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/ChecklistDiario.java
@@ -1,5 +1,6 @@
 package com.gamificacao.OdontoVision_API.model;
 
+import com.gamificacao.OdontoVision_API.model.enums.SimNao;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,8 +15,8 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 @Entity
-@Table(name = "pontuacao")
-public class Pontuacao {
+@Table(name = "checklist_diario")
+public class ChecklistDiario {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,25 +28,24 @@ public class Pontuacao {
 
     @NotNull
     @Column(nullable = false)
-    private Integer pontos;
+    private LocalDate data;
 
-    @NotNull
-    @Column(name = "data_registro", nullable = false)
-    private LocalDate dataRegistro;
+    @Column(length = 1)
+    private SimNao escovacao;
 
-    @Column(name = "ciclo_inicial")
-    private LocalDate cicloInicial;
+    @Column(name = "fio_dental", length = 1)
+    private SimNao fioDental;
 
-    @Column(name = "ciclo_final")
-    private LocalDate cicloFinal;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consulta_validacao_id")
+    private Consulta consultaValidacao;
 
-    public Pontuacao() {
+    public ChecklistDiario() {
     }
 
-    public Pontuacao(Usuario usuario, Integer pontos, LocalDate dataRegistro) {
+    public ChecklistDiario(Usuario usuario, LocalDate data) {
         this.usuario = usuario;
-        this.pontos = pontos;
-        this.dataRegistro = dataRegistro;
+        this.data = data;
     }
 
     public Long getId() {
@@ -60,42 +60,42 @@ public class Pontuacao {
         this.usuario = usuario;
     }
 
-    public Integer getPontos() {
-        return pontos;
+    public LocalDate getData() {
+        return data;
     }
 
-    public void setPontos(Integer pontos) {
-        this.pontos = pontos;
+    public void setData(LocalDate data) {
+        this.data = data;
     }
 
-    public LocalDate getDataRegistro() {
-        return dataRegistro;
+    public SimNao getEscovacao() {
+        return escovacao;
     }
 
-    public void setDataRegistro(LocalDate dataRegistro) {
-        this.dataRegistro = dataRegistro;
+    public void setEscovacao(SimNao escovacao) {
+        this.escovacao = escovacao;
     }
 
-    public LocalDate getCicloInicial() {
-        return cicloInicial;
+    public SimNao getFioDental() {
+        return fioDental;
     }
 
-    public void setCicloInicial(LocalDate cicloInicial) {
-        this.cicloInicial = cicloInicial;
+    public void setFioDental(SimNao fioDental) {
+        this.fioDental = fioDental;
     }
 
-    public LocalDate getCicloFinal() {
-        return cicloFinal;
+    public Consulta getConsultaValidacao() {
+        return consultaValidacao;
     }
 
-    public void setCicloFinal(LocalDate cicloFinal) {
-        this.cicloFinal = cicloFinal;
+    public void setConsultaValidacao(Consulta consultaValidacao) {
+        this.consultaValidacao = consultaValidacao;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Pontuacao that)) return false;
+        if (!(o instanceof ChecklistDiario that)) return false;
         return Objects.equals(id, that.id);
     }
 

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Conquista.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Conquista.java
@@ -1,0 +1,104 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "conquista")
+public class Conquista {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 100)
+    private String nome;
+
+    @NotBlank
+    @Column(nullable = false, length = 255)
+    private String descricao;
+
+    @Column(name = "pontos_bonus")
+    private Integer pontosBonus;
+
+    @Column(name = "data_expiracao")
+    private LocalDate dataExpiracao;
+
+    @OneToMany(mappedBy = "conquista")
+    private Set<UsuarioConquista> usuarios = new LinkedHashSet<>();
+
+    public Conquista() {
+    }
+
+    public Conquista(String nome, String descricao) {
+        this.nome = nome;
+        this.descricao = descricao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getPontosBonus() {
+        return pontosBonus;
+    }
+
+    public void setPontosBonus(Integer pontosBonus) {
+        this.pontosBonus = pontosBonus;
+    }
+
+    public LocalDate getDataExpiracao() {
+        return dataExpiracao;
+    }
+
+    public void setDataExpiracao(LocalDate dataExpiracao) {
+        this.dataExpiracao = dataExpiracao;
+    }
+
+    public Set<UsuarioConquista> getUsuarios() {
+        return usuarios;
+    }
+
+    public boolean estaValida(LocalDate dataReferencia) {
+        return dataExpiracao == null || !dataExpiracao.isBefore(dataReferencia);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Conquista conquista)) return false;
+        return Objects.equals(id, conquista.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Consulta.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Consulta.java
@@ -1,0 +1,162 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "consulta")
+public class Consulta {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(name = "data_hora", nullable = false)
+    private LocalDateTime dataHora;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dentista_id", nullable = false)
+    private Dentista dentista;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_id", nullable = false)
+    private StatusConsulta status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tipo_consulta_id", nullable = false)
+    private TipoConsulta tipoConsulta;
+
+    @Column(length = 255)
+    private String observacoes;
+
+    @ManyToMany
+    @JoinTable(name = "consulta_procedimento",
+            joinColumns = @JoinColumn(name = "consulta_id"),
+            inverseJoinColumns = @JoinColumn(name = "procedimento_id"))
+    private Set<Procedimento> procedimentos = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "consulta")
+    private Set<Diagnostico> diagnosticos = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "consultaValidacao")
+    private Set<ChecklistDiario> checklistsValidacoes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "consulta")
+    private Set<ValidacaoChecklist> validacoes = new LinkedHashSet<>();
+
+    public Consulta() {
+    }
+
+    public Consulta(LocalDateTime dataHora, Usuario usuario, Dentista dentista, StatusConsulta status, TipoConsulta tipoConsulta) {
+        this.dataHora = dataHora;
+        this.usuario = usuario;
+        this.dentista = dentista;
+        this.status = status;
+        this.tipoConsulta = tipoConsulta;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getDataHora() {
+        return dataHora;
+    }
+
+    public void setDataHora(LocalDateTime dataHora) {
+        this.dataHora = dataHora;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void definirUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Dentista getDentista() {
+        return dentista;
+    }
+
+    public void definirDentista(Dentista dentista) {
+        this.dentista = dentista;
+    }
+
+    public StatusConsulta getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusConsulta status) {
+        this.status = status;
+    }
+
+    public TipoConsulta getTipoConsulta() {
+        return tipoConsulta;
+    }
+
+    public void setTipoConsulta(TipoConsulta tipoConsulta) {
+        this.tipoConsulta = tipoConsulta;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    public Set<Procedimento> getProcedimentos() {
+        return procedimentos;
+    }
+
+    public Set<Diagnostico> getDiagnosticos() {
+        return diagnosticos;
+    }
+
+    public Set<ChecklistDiario> getChecklistsValidacoes() {
+        return checklistsValidacoes;
+    }
+
+    public Set<ValidacaoChecklist> getValidacoes() {
+        return validacoes;
+    }
+
+    public void adicionarProcedimento(Procedimento procedimento) {
+        procedimentos.add(procedimento);
+        procedimento.getConsultas().add(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Consulta consulta)) return false;
+        return Objects.equals(id, consulta.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Dentista.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Dentista.java
@@ -1,4 +1,156 @@
 package com.gamificacao.OdontoVision_API.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "dentista")
 public class Dentista {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 100)
+    private String nome;
+
+    @NotBlank
+    @Column(nullable = false, unique = true, length = 20)
+    private String cro;
+
+    @Size(max = 100)
+    private String especialidade;
+
+    @Size(max = 15)
+    private String telefone;
+
+    @NotBlank
+    @Email
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @OneToOne(mappedBy = "dentista", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private EnderecoClinica endereco;
+
+    @OneToMany(mappedBy = "dentista", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Consulta> consultas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "dentista", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HistoricoTratamento> historicosTratamento = new LinkedHashSet<>();
+
+    public Dentista() {
+    }
+
+    public Dentista(String nome, String cro, String especialidade, String telefone, String email) {
+        this.nome = nome;
+        this.cro = cro;
+        this.especialidade = especialidade;
+        this.telefone = telefone;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCro() {
+        return cro;
+    }
+
+    public void setCro(String cro) {
+        this.cro = cro;
+    }
+
+    public String getEspecialidade() {
+        return especialidade;
+    }
+
+    public void setEspecialidade(String especialidade) {
+        this.especialidade = especialidade;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public EnderecoClinica getEndereco() {
+        return endereco;
+    }
+
+    public void definirEndereco(EnderecoClinica endereco) {
+        if (endereco == null) {
+            if (this.endereco != null) {
+                this.endereco.definirDentista(null);
+            }
+            this.endereco = null;
+            return;
+        }
+        endereco.definirDentista(this);
+        this.endereco = endereco;
+    }
+
+    public Set<Consulta> getConsultas() {
+        return consultas;
+    }
+
+    public Set<HistoricoTratamento> getHistoricosTratamento() {
+        return historicosTratamento;
+    }
+
+    public void agendarConsulta(Consulta consulta) {
+        consulta.definirDentista(this);
+        consultas.add(consulta);
+    }
+
+    public void registrarTratamento(HistoricoTratamento historicoTratamento) {
+        historicoTratamento.setDentista(this);
+        historicosTratamento.add(historicoTratamento);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Dentista dentista)) return false;
+        return Objects.equals(id, dentista.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Diagnostico.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Diagnostico.java
@@ -1,0 +1,85 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "diagnostico")
+public class Diagnostico {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consulta_id", nullable = false)
+    private Consulta consulta;
+
+    @NotBlank
+    @Column(nullable = false, length = 255)
+    private String descricao;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDate data;
+
+    public Diagnostico() {
+    }
+
+    public Diagnostico(Consulta consulta, String descricao, LocalDate data) {
+        this.consulta = consulta;
+        this.descricao = descricao;
+        this.data = data;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Consulta getConsulta() {
+        return consulta;
+    }
+
+    public void setConsulta(Consulta consulta) {
+        this.consulta = consulta;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Diagnostico that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/EnderecoClinica.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/EnderecoClinica.java
@@ -1,0 +1,135 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+@Entity
+@Table(name = "endereco_clinica")
+public class EnderecoClinica {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dentista_id", nullable = false)
+    private Dentista dentista;
+
+    @NotBlank
+    @Column(length = 150)
+    private String logradouro;
+
+    @NotBlank
+    @Column(length = 10)
+    private String numero;
+
+    @NotBlank
+    @Column(length = 100)
+    private String cidade;
+
+    @NotBlank
+    @Column(length = 50)
+    private String estado;
+
+    @NotBlank
+    @Size(min = 8, max = 10)
+    @Column(length = 10)
+    private String cep;
+
+    @Column(length = 100)
+    private String complemento;
+
+    public EnderecoClinica() {
+    }
+
+    public EnderecoClinica(String logradouro, String numero, String cidade, String estado, String cep, String complemento) {
+        this.logradouro = logradouro;
+        this.numero = numero;
+        this.cidade = cidade;
+        this.estado = estado;
+        this.cep = cep;
+        this.complemento = complemento;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Dentista getDentista() {
+        return dentista;
+    }
+
+    public void definirDentista(Dentista dentista) {
+        this.dentista = dentista;
+    }
+
+    public String getLogradouro() {
+        return logradouro;
+    }
+
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public void setEstado(String estado) {
+        this.estado = estado;
+    }
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+
+    public String getComplemento() {
+        return complemento;
+    }
+
+    public void setComplemento(String complemento) {
+        this.complemento = complemento;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EnderecoClinica that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/EnderecoUsuario.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/EnderecoUsuario.java
@@ -1,0 +1,135 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+@Entity
+@Table(name = "endereco_usuario")
+public class EnderecoUsuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @NotBlank
+    @Column(length = 150)
+    private String logradouro;
+
+    @NotBlank
+    @Column(length = 10)
+    private String numero;
+
+    @NotBlank
+    @Column(length = 100)
+    private String cidade;
+
+    @NotBlank
+    @Column(length = 50)
+    private String estado;
+
+    @NotBlank
+    @Size(min = 8, max = 10)
+    @Column(length = 10)
+    private String cep;
+
+    @Column(length = 100)
+    private String complemento;
+
+    public EnderecoUsuario() {
+    }
+
+    public EnderecoUsuario(String logradouro, String numero, String cidade, String estado, String cep, String complemento) {
+        this.logradouro = logradouro;
+        this.numero = numero;
+        this.cidade = cidade;
+        this.estado = estado;
+        this.cep = cep;
+        this.complemento = complemento;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void definirUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public String getLogradouro() {
+        return logradouro;
+    }
+
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public void setEstado(String estado) {
+        this.estado = estado;
+    }
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+
+    public String getComplemento() {
+        return complemento;
+    }
+
+    public void setComplemento(String complemento) {
+        this.complemento = complemento;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EnderecoUsuario that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/HistoricoPontuacao.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/HistoricoPontuacao.java
@@ -1,4 +1,93 @@
 package com.gamificacao.OdontoVision_API.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "historico_pontuacao")
 public class HistoricoPontuacao {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(name = "data_consulta")
+    private LocalDate dataConsulta;
+
+    @Column(name = "pontos_ganhos")
+    private Integer pontosGanhos;
+
+    @Column(name = "pontos_totais")
+    private Integer pontosTotais;
+
+    public HistoricoPontuacao() {
+    }
+
+    public HistoricoPontuacao(Usuario usuario, LocalDate dataConsulta, Integer pontosGanhos, Integer pontosTotais) {
+        this.usuario = usuario;
+        this.dataConsulta = dataConsulta;
+        this.pontosGanhos = pontosGanhos;
+        this.pontosTotais = pontosTotais;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public LocalDate getDataConsulta() {
+        return dataConsulta;
+    }
+
+    public void setDataConsulta(LocalDate dataConsulta) {
+        this.dataConsulta = dataConsulta;
+    }
+
+    public Integer getPontosGanhos() {
+        return pontosGanhos;
+    }
+
+    public void setPontosGanhos(Integer pontosGanhos) {
+        this.pontosGanhos = pontosGanhos;
+    }
+
+    public Integer getPontosTotais() {
+        return pontosTotais;
+    }
+
+    public void setPontosTotais(Integer pontosTotais) {
+        this.pontosTotais = pontosTotais;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HistoricoPontuacao that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/HistoricoTratamento.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/HistoricoTratamento.java
@@ -1,0 +1,108 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "historico_tratamento")
+public class HistoricoTratamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "procedimento_id", nullable = false)
+    private Procedimento procedimento;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dentista_id", nullable = false)
+    private Dentista dentista;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDate data;
+
+    @Column(length = 255)
+    private String observacoes;
+
+    public HistoricoTratamento() {
+    }
+
+    public HistoricoTratamento(Usuario usuario, Procedimento procedimento, Dentista dentista, LocalDate data) {
+        this.usuario = usuario;
+        this.procedimento = procedimento;
+        this.dentista = dentista;
+        this.data = data;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Procedimento getProcedimento() {
+        return procedimento;
+    }
+
+    public void setProcedimento(Procedimento procedimento) {
+        this.procedimento = procedimento;
+    }
+
+    public Dentista getDentista() {
+        return dentista;
+    }
+
+    public void setDentista(Dentista dentista) {
+        this.dentista = dentista;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HistoricoTratamento that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Nivel.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Nivel.java
@@ -1,0 +1,82 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "nivel")
+public class Nivel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 100)
+    private String descricao;
+
+    @NotNull
+    @Column(name = "pontos_necessarios", nullable = false)
+    private Integer pontosNecessarios;
+
+    @OneToMany(mappedBy = "nivel")
+    private Set<UsuarioNivel> usuarios = new LinkedHashSet<>();
+
+    public Nivel() {
+    }
+
+    public Nivel(String descricao, Integer pontosNecessarios) {
+        this.descricao = descricao;
+        this.pontosNecessarios = pontosNecessarios;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getPontosNecessarios() {
+        return pontosNecessarios;
+    }
+
+    public void setPontosNecessarios(Integer pontosNecessarios) {
+        this.pontosNecessarios = pontosNecessarios;
+    }
+
+    public Set<UsuarioNivel> getUsuarios() {
+        return usuarios;
+    }
+
+    public boolean podeSerAlcancadoPor(int pontosAtuais) {
+        return pontosAtuais >= pontosNecessarios;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Nivel nivel)) return false;
+        return Objects.equals(id, nivel.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Notificacao.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Notificacao.java
@@ -1,0 +1,97 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "notificacao")
+public class Notificacao {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 100)
+    private String titulo;
+
+    @NotBlank
+    @Column(nullable = false, length = 255)
+    private String conteudo;
+
+    @NotNull
+    @Column(name = "data_envio", nullable = false)
+    private LocalDateTime dataEnvio;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    public Notificacao() {
+    }
+
+    public Notificacao(String titulo, String conteudo, LocalDateTime dataEnvio) {
+        this.titulo = titulo;
+        this.conteudo = conteudo;
+        this.dataEnvio = dataEnvio;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public void setTitulo(String titulo) {
+        this.titulo = titulo;
+    }
+
+    public String getConteudo() {
+        return conteudo;
+    }
+
+    public void setConteudo(String conteudo) {
+        this.conteudo = conteudo;
+    }
+
+    public LocalDateTime getDataEnvio() {
+        return dataEnvio;
+    }
+
+    public void setDataEnvio(LocalDateTime dataEnvio) {
+        this.dataEnvio = dataEnvio;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void definirUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Notificacao that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/PlanoCobertura.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/PlanoCobertura.java
@@ -1,0 +1,72 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+@Entity
+@Table(name = "plano_cobertura")
+public class PlanoCobertura {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plano_id", nullable = false)
+    private PlanoOdontologico plano;
+
+    @NotBlank
+    @Size(max = 255)
+    @Column(nullable = false)
+    private String descricao;
+
+    public PlanoCobertura() {
+    }
+
+    public PlanoCobertura(PlanoOdontologico plano, String descricao) {
+        this.plano = plano;
+        this.descricao = descricao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public PlanoOdontologico getPlano() {
+        return plano;
+    }
+
+    public void setPlano(PlanoOdontologico plano) {
+        this.plano = plano;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlanoCobertura that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/PlanoOdontologico.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/PlanoOdontologico.java
@@ -1,0 +1,124 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "plano_odontologico")
+public class PlanoOdontologico {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(name = "nome_plano", nullable = false, length = 100)
+    private String nomePlano;
+
+    @Size(max = 255)
+    private String descricao;
+
+    private BigDecimal preco;
+
+    private LocalDate validade;
+
+    @OneToMany(mappedBy = "plano", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsuarioPlano> adesoes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "plano", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<PlanoCobertura> coberturas = new LinkedHashSet<>();
+
+    @ManyToMany(mappedBy = "planos")
+    private Set<Procedimento> procedimentos = new LinkedHashSet<>();
+
+    public PlanoOdontologico() {
+    }
+
+    public PlanoOdontologico(String nomePlano) {
+        this.nomePlano = nomePlano;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNomePlano() {
+        return nomePlano;
+    }
+
+    public void setNomePlano(String nomePlano) {
+        this.nomePlano = nomePlano;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public BigDecimal getPreco() {
+        return preco;
+    }
+
+    public void setPreco(BigDecimal preco) {
+        this.preco = preco;
+    }
+
+    public LocalDate getValidade() {
+        return validade;
+    }
+
+    public void setValidade(LocalDate validade) {
+        this.validade = validade;
+    }
+
+    public Set<UsuarioPlano> getAdesoes() {
+        return adesoes;
+    }
+
+    public Set<PlanoCobertura> getCoberturas() {
+        return coberturas;
+    }
+
+    public Set<Procedimento> getProcedimentos() {
+        return procedimentos;
+    }
+
+    public void adicionarCobertura(String descricaoCobertura) {
+        PlanoCobertura cobertura = new PlanoCobertura(this, descricaoCobertura);
+        coberturas.add(cobertura);
+    }
+
+    public void associarProcedimento(Procedimento procedimento) {
+        procedimentos.add(procedimento);
+        procedimento.getPlanos().add(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlanoOdontologico that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Procedimento.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Procedimento.java
@@ -1,0 +1,104 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "procedimento")
+public class Procedimento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(name = "nome_procedimento", nullable = false, length = 100)
+    private String nomeProcedimento;
+
+    @Size(max = 255)
+    private String descricao;
+
+    private BigDecimal custo;
+
+    @ManyToMany(mappedBy = "procedimentos")
+    private Set<Consulta> consultas = new LinkedHashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "plano_procedimento",
+            joinColumns = @JoinColumn(name = "procedimento_id"),
+            inverseJoinColumns = @JoinColumn(name = "plano_id"))
+    private Set<PlanoOdontologico> planos = new LinkedHashSet<>();
+
+    public Procedimento() {
+    }
+
+    public Procedimento(String nomeProcedimento) {
+        this.nomeProcedimento = nomeProcedimento;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNomeProcedimento() {
+        return nomeProcedimento;
+    }
+
+    public void setNomeProcedimento(String nomeProcedimento) {
+        this.nomeProcedimento = nomeProcedimento;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public BigDecimal getCusto() {
+        return custo;
+    }
+
+    public void setCusto(BigDecimal custo) {
+        this.custo = custo;
+    }
+
+    public Set<Consulta> getConsultas() {
+        return consultas;
+    }
+
+    public Set<PlanoOdontologico> getPlanos() {
+        return planos;
+    }
+
+    public void associarPlano(PlanoOdontologico plano) {
+        planos.add(plano);
+        plano.getProcedimentos().add(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Procedimento that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Recompensa.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Recompensa.java
@@ -1,4 +1,115 @@
 package com.gamificacao.OdontoVision_API.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "recompensa")
 public class Recompensa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 255)
+    private String descricao;
+
+    @NotNull
+    @Column(name = "pontos_necessarios", nullable = false)
+    private Integer pontosNecessarios;
+
+    @Column(name = "quantidade_disponivel")
+    private Integer quantidadeDisponivel;
+
+    @Column(name = "data_expiracao")
+    private LocalDate dataExpiracao;
+
+    @OneToMany(mappedBy = "recompensa")
+    private Set<UsuarioRecompensa> resgates = new LinkedHashSet<>();
+
+    public Recompensa() {
+    }
+
+    public Recompensa(String descricao, Integer pontosNecessarios) {
+        this.descricao = descricao;
+        this.pontosNecessarios = pontosNecessarios;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getPontosNecessarios() {
+        return pontosNecessarios;
+    }
+
+    public void setPontosNecessarios(Integer pontosNecessarios) {
+        this.pontosNecessarios = pontosNecessarios;
+    }
+
+    public Integer getQuantidadeDisponivel() {
+        return quantidadeDisponivel;
+    }
+
+    public void setQuantidadeDisponivel(Integer quantidadeDisponivel) {
+        this.quantidadeDisponivel = quantidadeDisponivel;
+    }
+
+    public LocalDate getDataExpiracao() {
+        return dataExpiracao;
+    }
+
+    public void setDataExpiracao(LocalDate dataExpiracao) {
+        this.dataExpiracao = dataExpiracao;
+    }
+
+    public Set<UsuarioRecompensa> getResgates() {
+        return resgates;
+    }
+
+    public void registrarResgate(UsuarioRecompensa usuarioRecompensa) {
+        resgates.add(usuarioRecompensa);
+    }
+
+    public boolean possuiEstoqueDisponivel() {
+        return quantidadeDisponivel == null || quantidadeDisponivel > 0;
+    }
+
+    public void diminuirEstoque() {
+        if (quantidadeDisponivel != null && quantidadeDisponivel > 0) {
+            quantidadeDisponivel--;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Recompensa recompensa)) return false;
+        return Objects.equals(id, recompensa.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Sinistro.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Sinistro.java
@@ -1,0 +1,105 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import com.gamificacao.OdontoVision_API.model.enums.SimNao;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "sinistro")
+public class Sinistro {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id")
+    private Usuario paciente;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "procedimento_id")
+    private Procedimento procedimento;
+
+    @Column(name = "data_sinistro")
+    private LocalDate dataSinistro;
+
+    @Column(name = "risco_fraude", length = 1)
+    private SimNao riscoFraude;
+
+    @Column(name = "descricao_risco", length = 255)
+    private String descricaoRisco;
+
+    public Sinistro() {
+    }
+
+    public Sinistro(Usuario paciente, Procedimento procedimento, LocalDate dataSinistro) {
+        this.paciente = paciente;
+        this.procedimento = procedimento;
+        this.dataSinistro = dataSinistro;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getPaciente() {
+        return paciente;
+    }
+
+    public void definirPaciente(Usuario paciente) {
+        this.paciente = paciente;
+    }
+
+    public Procedimento getProcedimento() {
+        return procedimento;
+    }
+
+    public void setProcedimento(Procedimento procedimento) {
+        this.procedimento = procedimento;
+    }
+
+    public LocalDate getDataSinistro() {
+        return dataSinistro;
+    }
+
+    public void setDataSinistro(LocalDate dataSinistro) {
+        this.dataSinistro = dataSinistro;
+    }
+
+    public SimNao getRiscoFraude() {
+        return riscoFraude;
+    }
+
+    public void setRiscoFraude(SimNao riscoFraude) {
+        this.riscoFraude = riscoFraude;
+    }
+
+    public String getDescricaoRisco() {
+        return descricaoRisco;
+    }
+
+    public void setDescricaoRisco(String descricaoRisco) {
+        this.descricaoRisco = descricaoRisco;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Sinistro sinistro)) return false;
+        return Objects.equals(id, sinistro.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/StatusConsulta.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/StatusConsulta.java
@@ -1,0 +1,54 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Objects;
+
+@Entity
+@Table(name = "status_consulta")
+public class StatusConsulta {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, unique = true, length = 20)
+    private String descricao;
+
+    public StatusConsulta() {
+    }
+
+    public StatusConsulta(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StatusConsulta that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/TipoConsulta.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/TipoConsulta.java
@@ -1,0 +1,54 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Objects;
+
+@Entity
+@Table(name = "tipo_consulta")
+public class TipoConsulta {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, unique = true, length = 50)
+    private String descricao;
+
+    public TipoConsulta() {
+    }
+
+    public TipoConsulta(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TipoConsulta that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/Usuario.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/Usuario.java
@@ -1,4 +1,281 @@
 package com.gamificacao.OdontoVision_API.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "usuario")
 public class Usuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 100)
+    private String nome;
+
+    @NotBlank
+    @Email
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 100)
+    @Column(nullable = false, length = 100)
+    private String senha;
+
+    @Past
+    @Column(name = "data_nascimento")
+    private LocalDate dataNascimento;
+
+    @NotBlank
+    @Size(min = 11, max = 11)
+    @Column(nullable = false, unique = true, length = 11)
+    private String cpf;
+
+    @Column(length = 15)
+    private String telefone;
+
+    @OneToOne(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private EnderecoUsuario endereco;
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsuarioPlano> planos = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Pontuacao> pontuacoes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HistoricoPontuacao> historicoPontuacoes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsuarioRecompensa> recompensasResgatadas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsuarioNivel> niveis = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsuarioConquista> conquistas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ChecklistDiario> checklists = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ValidacaoChecklist> validacoesChecklist = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Notificacao> notificacoes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Consulta> consultas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "paciente", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Sinistro> sinistros = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HistoricoTratamento> historicosTratamento = new LinkedHashSet<>();
+
+    public Usuario() {
+    }
+
+    public Usuario(String nome, String email, String senha, LocalDate dataNascimento, String cpf, String telefone) {
+        this.nome = nome;
+        this.email = email;
+        this.senha = senha;
+        this.dataNascimento = dataNascimento;
+        this.cpf = cpf;
+        this.telefone = telefone;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+
+    public LocalDate getDataNascimento() {
+        return dataNascimento;
+    }
+
+    public void setDataNascimento(LocalDate dataNascimento) {
+        this.dataNascimento = dataNascimento;
+    }
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public EnderecoUsuario getEndereco() {
+        return endereco;
+    }
+
+    public void definirEndereco(EnderecoUsuario endereco) {
+        if (endereco == null) {
+            if (this.endereco != null) {
+                this.endereco.definirUsuario(null);
+            }
+            this.endereco = null;
+            return;
+        }
+        endereco.definirUsuario(this);
+        this.endereco = endereco;
+    }
+
+    public Set<UsuarioPlano> getPlanos() {
+        return planos;
+    }
+
+    public Set<Pontuacao> getPontuacoes() {
+        return pontuacoes;
+    }
+
+    public Set<HistoricoPontuacao> getHistoricoPontuacoes() {
+        return historicoPontuacoes;
+    }
+
+    public Set<UsuarioRecompensa> getRecompensasResgatadas() {
+        return recompensasResgatadas;
+    }
+
+    public Set<UsuarioNivel> getNiveis() {
+        return niveis;
+    }
+
+    public Set<UsuarioConquista> getConquistas() {
+        return conquistas;
+    }
+
+    public Set<ChecklistDiario> getChecklists() {
+        return checklists;
+    }
+
+    public Set<ValidacaoChecklist> getValidacoesChecklist() {
+        return validacoesChecklist;
+    }
+
+    public Set<Notificacao> getNotificacoes() {
+        return notificacoes;
+    }
+
+    public Set<Consulta> getConsultas() {
+        return consultas;
+    }
+
+    public Set<Sinistro> getSinistros() {
+        return sinistros;
+    }
+
+    public Set<HistoricoTratamento> getHistoricosTratamento() {
+        return historicosTratamento;
+    }
+
+    public void adicionarPlano(UsuarioPlano usuarioPlano) {
+        usuarioPlano.definirUsuario(this);
+        planos.add(usuarioPlano);
+    }
+
+    public void adicionarPontuacao(Pontuacao pontuacao) {
+        pontuacao.definirUsuario(this);
+        pontuacoes.add(pontuacao);
+    }
+
+    public void adicionarChecklist(ChecklistDiario checklistDiario) {
+        checklistDiario.definirUsuario(this);
+        checklists.add(checklistDiario);
+    }
+
+    public void adicionarNotificacao(Notificacao notificacao) {
+        notificacao.definirUsuario(this);
+        notificacoes.add(notificacao);
+    }
+
+    public void agendarConsulta(Consulta consulta) {
+        consulta.definirUsuario(this);
+        consultas.add(consulta);
+    }
+
+    public void registrarSinistro(Sinistro sinistro) {
+        sinistro.definirPaciente(this);
+        sinistros.add(sinistro);
+    }
+
+    public void registrarNivel(UsuarioNivel usuarioNivel) {
+        usuarioNivel.setUsuario(this);
+        niveis.add(usuarioNivel);
+    }
+
+    public void adicionarConquista(UsuarioConquista usuarioConquista) {
+        usuarioConquista.setUsuario(this);
+        conquistas.add(usuarioConquista);
+    }
+
+    public void registrarResgate(Recompensa recompensa, UsuarioRecompensa usuarioRecompensa) {
+        usuarioRecompensa.setUsuario(this);
+        usuarioRecompensa.setRecompensa(recompensa);
+        recompensasResgatadas.add(usuarioRecompensa);
+        recompensa.registrarResgate(usuarioRecompensa);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Usuario usuario)) return false;
+        return Objects.equals(id, usuario.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioConquista.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioConquista.java
@@ -1,0 +1,83 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import com.gamificacao.OdontoVision_API.model.id.UsuarioConquistaId;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "usuario_conquista")
+public class UsuarioConquista {
+
+    @EmbeddedId
+    private UsuarioConquistaId id = new UsuarioConquistaId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("usuarioId")
+    @JoinColumn(name = "usuario_id")
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("conquistaId")
+    @JoinColumn(name = "conquista_id")
+    private Conquista conquista;
+
+    @Column(name = "data_obtencao")
+    private LocalDate dataObtencao = LocalDate.now();
+
+    public UsuarioConquista() {
+    }
+
+    public UsuarioConquista(Usuario usuario, Conquista conquista) {
+        this.usuario = usuario;
+        this.conquista = conquista;
+        this.id = new UsuarioConquistaId(usuario.getId(), conquista.getId());
+    }
+
+    public UsuarioConquistaId getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Conquista getConquista() {
+        return conquista;
+    }
+
+    public void setConquista(Conquista conquista) {
+        this.conquista = conquista;
+    }
+
+    public LocalDate getDataObtencao() {
+        return dataObtencao;
+    }
+
+    public void setDataObtencao(LocalDate dataObtencao) {
+        this.dataObtencao = dataObtencao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UsuarioConquista that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioNivel.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioNivel.java
@@ -1,0 +1,99 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import com.gamificacao.OdontoVision_API.model.id.UsuarioNivelId;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "usuario_nivel")
+public class UsuarioNivel {
+
+    @EmbeddedId
+    private UsuarioNivelId id = new UsuarioNivelId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("usuarioId")
+    @JoinColumn(name = "usuario_id")
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("nivelId")
+    @JoinColumn(name = "nivel_id")
+    private Nivel nivel;
+
+    @Column(name = "pontos_atuais", nullable = false)
+    private Integer pontosAtuais;
+
+    @Column(name = "data_ultima_atualizacao")
+    private LocalDate dataUltimaAtualizacao = LocalDate.now();
+
+    public UsuarioNivel() {
+    }
+
+    public UsuarioNivel(Usuario usuario, Nivel nivel, Integer pontosAtuais) {
+        this.usuario = usuario;
+        this.nivel = nivel;
+        this.pontosAtuais = pontosAtuais;
+        this.id = new UsuarioNivelId(usuario.getId(), nivel.getId());
+    }
+
+    public UsuarioNivelId getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Nivel getNivel() {
+        return nivel;
+    }
+
+    public void setNivel(Nivel nivel) {
+        this.nivel = nivel;
+    }
+
+    public Integer getPontosAtuais() {
+        return pontosAtuais;
+    }
+
+    public void setPontosAtuais(Integer pontosAtuais) {
+        this.pontosAtuais = pontosAtuais;
+    }
+
+    public LocalDate getDataUltimaAtualizacao() {
+        return dataUltimaAtualizacao;
+    }
+
+    public void setDataUltimaAtualizacao(LocalDate dataUltimaAtualizacao) {
+        this.dataUltimaAtualizacao = dataUltimaAtualizacao;
+    }
+
+    public boolean podeSubirNivel() {
+        return nivel != null && pontosAtuais != null && nivel.podeSerAlcancadoPor(pontosAtuais);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UsuarioNivel that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioPlano.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/UsuarioPlano.java
@@ -9,12 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Objects;
 
 @Entity
-@Table(name = "usuario_recompensa")
-public class UsuarioRecompensa {
+@Table(name = "usuario_plano")
+public class UsuarioPlano {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,18 +26,19 @@ public class UsuarioRecompensa {
     private Usuario usuario;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recompensa_id", nullable = false)
-    private Recompensa recompensa;
+    @JoinColumn(name = "plano_id", nullable = false)
+    private PlanoOdontologico plano;
 
-    @Column(name = "data_resgate")
-    private LocalDate dataResgate = LocalDate.now();
+    @NotNull
+    @Column(name = "data_adesao")
+    private LocalDate dataAdesao = LocalDate.now();
 
-    public UsuarioRecompensa() {
+    public UsuarioPlano() {
     }
 
-    public UsuarioRecompensa(Usuario usuario, Recompensa recompensa) {
+    public UsuarioPlano(Usuario usuario, PlanoOdontologico plano) {
         this.usuario = usuario;
-        this.recompensa = recompensa;
+        this.plano = plano;
     }
 
     public Long getId() {
@@ -47,30 +49,30 @@ public class UsuarioRecompensa {
         return usuario;
     }
 
-    public void setUsuario(Usuario usuario) {
+    public void definirUsuario(Usuario usuario) {
         this.usuario = usuario;
     }
 
-    public Recompensa getRecompensa() {
-        return recompensa;
+    public PlanoOdontologico getPlano() {
+        return plano;
     }
 
-    public void setRecompensa(Recompensa recompensa) {
-        this.recompensa = recompensa;
+    public void setPlano(PlanoOdontologico plano) {
+        this.plano = plano;
     }
 
-    public LocalDate getDataResgate() {
-        return dataResgate;
+    public LocalDate getDataAdesao() {
+        return dataAdesao;
     }
 
-    public void setDataResgate(LocalDate dataResgate) {
-        this.dataResgate = dataResgate;
+    public void setDataAdesao(LocalDate dataAdesao) {
+        this.dataAdesao = dataAdesao;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UsuarioRecompensa that)) return false;
+        if (!(o instanceof UsuarioPlano that)) return false;
         return Objects.equals(id, that.id);
     }
 

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/ValidacaoChecklist.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/ValidacaoChecklist.java
@@ -1,0 +1,105 @@
+package com.gamificacao.OdontoVision_API.model;
+
+import com.gamificacao.OdontoVision_API.model.enums.SimNao;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "validacao_checklist")
+public class ValidacaoChecklist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consulta_id", nullable = false)
+    private Consulta consulta;
+
+    @Column(name = "data_validacao")
+    private LocalDate dataValidacao = LocalDate.now();
+
+    @Column(name = "status_validacao", length = 1)
+    private SimNao statusValidacao;
+
+    @Column(name = "pontos_bonus")
+    private Integer pontosBonus;
+
+    public ValidacaoChecklist() {
+    }
+
+    public ValidacaoChecklist(Usuario usuario, Consulta consulta, SimNao statusValidacao) {
+        this.usuario = usuario;
+        this.consulta = consulta;
+        this.statusValidacao = statusValidacao;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Consulta getConsulta() {
+        return consulta;
+    }
+
+    public void setConsulta(Consulta consulta) {
+        this.consulta = consulta;
+    }
+
+    public LocalDate getDataValidacao() {
+        return dataValidacao;
+    }
+
+    public void setDataValidacao(LocalDate dataValidacao) {
+        this.dataValidacao = dataValidacao;
+    }
+
+    public SimNao getStatusValidacao() {
+        return statusValidacao;
+    }
+
+    public void setStatusValidacao(SimNao statusValidacao) {
+        this.statusValidacao = statusValidacao;
+    }
+
+    public Integer getPontosBonus() {
+        return pontosBonus;
+    }
+
+    public void setPontosBonus(Integer pontosBonus) {
+        this.pontosBonus = pontosBonus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ValidacaoChecklist that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/converter/SimNaoConverter.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/converter/SimNaoConverter.java
@@ -1,0 +1,22 @@
+package com.gamificacao.OdontoVision_API.model.converter;
+
+import com.gamificacao.OdontoVision_API.model.enums.SimNao;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class SimNaoConverter implements AttributeConverter<SimNao, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SimNao attribute) {
+        return attribute == null ? null : String.valueOf(attribute.getCodigo());
+    }
+
+    @Override
+    public SimNao convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        return SimNao.fromCodigo(dbData.charAt(0));
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/enums/SimNao.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/enums/SimNao.java
@@ -1,0 +1,25 @@
+package com.gamificacao.OdontoVision_API.model.enums;
+
+public enum SimNao {
+    SIM('S'),
+    NAO('N');
+
+    private final char codigo;
+
+    SimNao(char codigo) {
+        this.codigo = codigo;
+    }
+
+    public char getCodigo() {
+        return codigo;
+    }
+
+    public static SimNao fromCodigo(char codigo) {
+        for (SimNao value : values()) {
+            if (value.codigo == Character.toUpperCase(codigo)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Código inválido para SimNao: " + codigo);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/id/UsuarioConquistaId.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/id/UsuarioConquistaId.java
@@ -1,0 +1,52 @@
+package com.gamificacao.OdontoVision_API.model.id;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class UsuarioConquistaId implements Serializable {
+
+    @Column(name = "usuario_id")
+    private Long usuarioId;
+
+    @Column(name = "conquista_id")
+    private Long conquistaId;
+
+    public UsuarioConquistaId() {
+    }
+
+    public UsuarioConquistaId(Long usuarioId, Long conquistaId) {
+        this.usuarioId = usuarioId;
+        this.conquistaId = conquistaId;
+    }
+
+    public Long getUsuarioId() {
+        return usuarioId;
+    }
+
+    public Long getConquistaId() {
+        return conquistaId;
+    }
+
+    public void setUsuarioId(Long usuarioId) {
+        this.usuarioId = usuarioId;
+    }
+
+    public void setConquistaId(Long conquistaId) {
+        this.conquistaId = conquistaId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UsuarioConquistaId that)) return false;
+        return Objects.equals(usuarioId, that.usuarioId) && Objects.equals(conquistaId, that.conquistaId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(usuarioId, conquistaId);
+    }
+}

--- a/src/main/java/com/gamificacao/OdontoVision_API/model/id/UsuarioNivelId.java
+++ b/src/main/java/com/gamificacao/OdontoVision_API/model/id/UsuarioNivelId.java
@@ -1,0 +1,52 @@
+package com.gamificacao.OdontoVision_API.model.id;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class UsuarioNivelId implements Serializable {
+
+    @Column(name = "usuario_id")
+    private Long usuarioId;
+
+    @Column(name = "nivel_id")
+    private Long nivelId;
+
+    public UsuarioNivelId() {
+    }
+
+    public UsuarioNivelId(Long usuarioId, Long nivelId) {
+        this.usuarioId = usuarioId;
+        this.nivelId = nivelId;
+    }
+
+    public Long getUsuarioId() {
+        return usuarioId;
+    }
+
+    public Long getNivelId() {
+        return nivelId;
+    }
+
+    public void setUsuarioId(Long usuarioId) {
+        this.usuarioId = usuarioId;
+    }
+
+    public void setNivelId(Long nivelId) {
+        this.nivelId = nivelId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UsuarioNivelId that)) return false;
+        return Objects.equals(usuarioId, that.usuarioId) && Objects.equals(nivelId, that.nivelId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(usuarioId, nivelId);
+    }
+}


### PR DESCRIPTION
## Summary
- implement rich JPA entities for the OdontoVision domain covering users, plans, consultations, gamification and auditing data
- add helper behaviors on core aggregates such as Usuario, PlanoOdontologico, Recompensa and Consulta to keep associations consistent
- introduce the SimNao enum with an auto-applied converter to map legacy S/N flags to type-safe fields across the new models

## Testing
- `./mvnw -q -DskipTests compile` *(fails: resource filtering error in application.properties unrelated to new entities)*

------
https://chatgpt.com/codex/tasks/task_e_68d85da30764832b8f37838dbeac7d7b